### PR TITLE
Fix option handling in pipeline.jl

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -55,7 +55,8 @@ end
 # TODO: support "CREATE OR REPLACE" & "IF NOT EXISTS" for all create_* functions
 
 function _create_tbl_impl(con::DB, query::String; name::String, tmp::Bool, show::Bool)
-    DBInterface.execute(con, "CREATE $(tmp ? "TEMP" : "") TABLE $name AS $query")
+    create_table_cmd = "CREATE" * (tmp ? " TEMP" : "") * " TABLE"
+    DBInterface.execute(con, "$create_table_cmd $name AS $query")
     return show ? DF.DataFrame(DBInterface.execute(con, "SELECT * FROM $name")) : name
 end
 
@@ -105,7 +106,7 @@ function create_tbl(
     end
     query = fmt_select(fmt_read(source; _read_opts..., kwargs...))
 
-    if (length(name) == 0)
+    if length(name) == 0
         name = get_tbl_name(source, tmp)
     end
 
@@ -170,7 +171,7 @@ function create_tbl(
     sources = [fmt_source(con, src) for src in (base_source, alt_source)]
     query = fmt_join(sources...; on = on, cols = cols, fill = fill, fill_values = fill_values)
 
-    if (length(name) == 0)
+    if length(name) == 0
         name = get_tbl_name(alt_source, tmp)
     end
 
@@ -303,7 +304,7 @@ function set_tbl_col(
     tmp::Bool = false,
     show::Bool = false,
 ) where {T}
-    if (length(name) == 0)
+    if length(name) == 0
         name = get_tbl_name(source, tmp)
     end
 
@@ -340,7 +341,7 @@ function select(
     src = fmt_source(con, source)
     query = "SELECT * FROM $src WHERE $expression"
 
-    if (length(name) == 0)
+    if length(name) == 0
         name = get_tbl_name(source, tmp)
     end
 

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -175,7 +175,7 @@ function create_tbl(
     tmp::Bool = false,
     show::Bool = false,
 )
-    if (check_file(alt_source) && length(name) == 0)
+    if check_file(alt_source) && length(name) == 0
         name = get_tbl_name(alt_source, tmp)
     end
 
@@ -246,7 +246,7 @@ function set_tbl_col(
     # columns?  If such a feature is required, we can use
     # cols::Dict{Symbol, Vector{Any}}, and get the cols and vals
     # as: keys(cols), and values(cols)
-    if (check_file(source) && length(name) == 0)
+    if check_file(source) && length(name) == 0
         name = get_tbl_name(source, tmp)
     end
 
@@ -314,7 +314,7 @@ function set_tbl_col(
     tmp::Bool = false,
     show::Bool = false,
 ) where {T}
-    if (check_file(source) && length(name) == 0)
+    if check_file(source) && length(name) == 0
         name = get_tbl_name(source, tmp)
     end
 
@@ -350,7 +350,7 @@ function select(
     src = fmt_source(con, source)
     query = "SELECT * FROM $src WHERE $expression"
 
-    if (check_file(source) && length(name) == 0)
+    if check_file(source) && length(name) == 0
         name = get_tbl_name(source, tmp)
     end
 

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -46,6 +46,13 @@ end
 Store() = Store(":memory:")
 DEFAULT = Store()
 
+"""
+    get_tbl_name(source::String, tmp::Bool)
+
+Generate table name from a filename by removing special characters.
+If `tmp` is true, then the table name is prefixed by 't_'.
+
+"""
 function get_tbl_name(source::String, tmp::Bool)
     name, _ = splitext(basename(source))
     name = replace(name, r"[ ()\[\]{}\\+,.-]+" => "_")

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -55,13 +55,8 @@ end
 # TODO: support "CREATE OR REPLACE" & "IF NOT EXISTS" for all create_* functions
 
 function _create_tbl_impl(con::DB, query::String; name::String, tmp::Bool, show::Bool)
-    if length(name) > 0
-        DBInterface.execute(con, "CREATE $(tmp ? "TEMP" : "") TABLE $name AS $query")
-        return show ? DF.DataFrame(DBInterface.execute(con, "SELECT * FROM $name")) : name
-    else # only show
-        res = DBInterface.execute(con, query)
-        return DF.DataFrame(res)
-    end
+    DBInterface.execute(con, "CREATE $(tmp ? "TEMP" : "") TABLE $name AS $query")
+    return show ? DF.DataFrame(DBInterface.execute(con, "SELECT * FROM $name")) : name
 end
 
 """

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -31,7 +31,7 @@ end
 
     @testset "get_tbl_name(source, tmp)" begin
         for (name, tmp) in [["my_file", false], ["t_my_file", true]]
-            @test name == TIO.get_tbl_name("my-file.csv", tmp)
+            @test name == TIO.get_tbl_name("path/my-file.csv", tmp)
         end
     end
 

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -29,6 +29,29 @@ end
 @testset "Utilities" begin
     csv_path = joinpath(DATA, "Norse/assets-data.csv")
 
+    @testset "option handling" begin
+        @testset "table name is specified -> noop" begin
+            for (tmp, show) in Base.Iterators.product([true, false], [true, false])
+                @test ("foo", tmp, show) == TIO._handle_opts("my-file.csv", "foo", tmp, show)
+            end
+        end
+
+        @testset "show=true: `name` & `tmp` ignored" begin
+            for tmp in [true, false]
+                name, _ = TIO._handle_opts("my-file.csv", "", tmp, true)
+                @test name == ""
+            end
+        end
+
+        @testset "tmp=false & show=false: force `tmp` with empty `name`" begin
+            for (name, new_name, new_tmp) in [["", "t_my_file", true], ["foo", "foo", false]]
+                name, tmp, _ = TIO._handle_opts("my-file.csv", name, false, false)
+                @test name == new_name
+                @test tmp == new_tmp
+            end
+        end
+    end
+
     # redundant for the current implementation, needed when we support globs
     @test TIO.check_file(csv_path)
     @test !TIO.check_file("not-there")

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -32,20 +32,20 @@ end
     @testset "option handling" begin
         @testset "table name is specified -> noop" begin
             for (tmp, show) in Base.Iterators.product([true, false], [true, false])
-                @test ("foo", tmp, show) == TIO._handle_opts("my-file.csv", "foo", tmp, show)
+                @test ("foo", tmp, show) == TIO._handle_opts("my-file.csv", "foo", tmp, Val(show))
             end
         end
 
         @testset "show=true: `name` & `tmp` ignored" begin
             for tmp in [true, false]
-                name, _ = TIO._handle_opts("my-file.csv", "", tmp, true)
+                name, _ = TIO._handle_opts("my-file.csv", "", tmp, Val(true))
                 @test name == ""
             end
         end
 
         @testset "tmp=false & show=false: force `tmp` with empty `name`" begin
             for (name, new_name, new_tmp) in [["", "t_my_file", true], ["foo", "foo", false]]
-                name, tmp, _ = TIO._handle_opts("my-file.csv", name, false, false)
+                name, tmp, _ = TIO._handle_opts("my-file.csv", name, false, Val(false))
                 @test name == new_name
                 @test tmp == new_tmp
             end

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -239,6 +239,9 @@ end
         con = DBInterface.connect(DB)
         df_res = TIO.set_tbl_col(con, csv_path, Dict(:investable => true); opts...)
         @test df_res.investable |> all
+
+        table_name = TIO.set_tbl_col(con, csv_path, Dict(:investable => true); on = :name)
+        @test "assets_data" == table_name
     end
 
     @testset "w/ constant after filtering" begin


### PR DESCRIPTION
Resolves the confusion among the options.

The only "automatic" behaviour is when the source is a file, and no table name has been provided.  In that case, it generates a table name by removing special characters from the filename.  If `tmp=true`, the generated table name has a `t_*` prefix.

| name      | tmp         | remarks                          |
|-----------|-------------|----------------------------------|
| non-empty | as provided |                                  |
| empty     | true        | table name: `t_<safe_filename>`  |
| empty     | false       | table name: `<safe_filename>`    |

All other options work independently:
- `name::String` sets the table name
- `tmp::Bool` creates the table as a temporary in-memory table
- `show::Bool` returns the created table as a dataframe

Also refactor most of the test suite to isolated tests as much as possible.  Some are unavoidable, since they need some existing state (e.g. a base table), and there is no nice way to do fixtures.

## Related issues

Closes #31 

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaIO.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
