### PR TITLE
docs(readme): Remove extra closing parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Coverage](https://codecov.io/gh/TulipaEnergy/TulipaIO.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/TulipaEnergy/TulipaIO.jl)
 [![DOI](https://zenodo.org/badge/756428717.svg)](https://doi.org/10.5281/zenodo.11178467)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-[![All Contributors](https://img.shields.io/github/all-contributors/TulipaEnergy/TulipaIO.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square))](#contributors)
+[![All Contributors](https://img.shields.io/github/all-contributors/TulipaEnergy/TulipaIO.jl?labelColor=5e1ec7&color=c0ffee&style=flat-square)](#contributors)
 
 ## About `TulipaIO.jl` (`TIO`)
 


### PR DESCRIPTION
Currently this is how the README renders on Github:

<img width="615" alt="image" src="https://github.com/user-attachments/assets/bc2812dd-539c-4ddd-b997-667556c86dd9" />

Notice an extra closing parentheses at the end.

This PR fixes the typo by removing the extra closing parentheses.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaIO.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
