### PR TITLE
convenience.jl: accept keyword options for DuckDB's read_csv

### DIFF
--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -12,6 +12,7 @@ Read all CSV files in the `folder` and create a table for each in the `connectio
 - `schemas = Dict()` Dictionary of dictionaries, where the inner
   dictionary is a table schema (partial schemas are allowed).  The
   keys of the outer dictionary are the table names
+- opts... are keyword options that are passed on to DuckDB's `read_csv` function
 """
 function read_csv_folder(
     connection,
@@ -19,6 +20,7 @@ function read_csv_folder(
     table_name_prefix = "",
     table_name_suffix = "",
     schemas = Dict(),
+    opts...,
 )
     for filename in readdir(folder)
         if !endswith(".csv")(filename)
@@ -29,7 +31,7 @@ function read_csv_folder(
         table_name = table_name_prefix * table_name * table_name_suffix
 
         types = get(schemas, table_name, Dict())
-        create_tbl(connection, joinpath(folder, filename); name = table_name, types)
+        create_tbl(connection, joinpath(folder, filename); name = table_name, types, opts...)
     end
 
     return connection


### PR DESCRIPTION
<!--
Thanks for making a pull request to TulipaIO.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
There is no related issue.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [X] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaIO.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [X] Lint workflow is passing
- [X] Docs were updated and workflow is passing
