### PR TITLE
workflows: enable CI for Windows on PRs

### DIFF
--- a/.github/workflows/TestOnPRs.yml
+++ b/.github/workflows/TestOnPRs.yml
@@ -18,9 +18,12 @@ concurrency:
 
 jobs:
     test:
+        strategy:
+            matrix:
+                os: ["ubuntu-latest", "windows-latest"]
         uses: ./.github/workflows/ReusableTest.yml
         with:
-            os: ubuntu-latest
+            os: ${{ matrix.os }}
             version: "1"
             arch: x64
             allow_failure: false


### PR DESCRIPTION
Since now we are handling paths, it is important to test on both *nix & Windows

## Related issues

There is no related issue.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaIO.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
