### PR TITLE
pipeline.jl: convert platform specific path to posix for glob

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -4,7 +4,7 @@ using Glob: glob
 
 using .FmtSQL: fmt_join, fmt_read, fmt_select
 
-export create_tbl, tbl_select, as_table, select_tbl, rename_cols, update_tbl, tbl_cols
+export create_tbl, as_table, select_tbl, rename_cols, update_tbl, tbl_cols
 
 # default options for reading
 _read_opts = pairs((header = true,))

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -9,8 +9,12 @@ export create_tbl, tbl_select, as_table, select_tbl, rename_cols, update_tbl, tb
 # default options for reading
 _read_opts = pairs((header = true,))
 
+to_posix(path::String) = replace(path, "\\" => "/")
+
 function check_file(source::String)
-    files = glob(relpath(source, pwd()))
+    # NOTE: this is necessary since `glob` accepts only POSIX paths
+    # regardless of platform
+    files = source |> relpath |> to_posix |> glob
     length(files) > 0
 end
 

--- a/test/test-convenience.jl
+++ b/test/test-convenience.jl
@@ -9,14 +9,6 @@ using TulipaIO: TulipaIO
         csv_file = joinpath(tmpdir, "some-file.csv")
         CSV.write(csv_file, DataFrame(:a => ["A", "B", "C"], :x => rand(3)))
 
-        # Debugging information
-        println("CSV file path: ", csv_file)
-        println("CSV file exists: ", isfile(csv_file))
-        println("CSV file is regular file: ", isfile(csv_file) && !isdir(csv_file))
-
-        # Ensure the file is a regular file
-        @test isfile(csv_file) && !isdir(csv_file)
-
         open(joinpath(tmpdir, "ignore-this-file.txt"), "w") do io
             println(io, "Nothing")
         end

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -35,6 +35,7 @@ end
 
     # redundant for the current implementation, needed when we support globs
     @testset "check_file(source)" begin
+        csv_path = joinpath(DATA, "Norse", "assets*.csv")
         @test TulipaIO.check_file(csv_path)
         @test !TulipaIO.check_file("not-there")
     end

--- a/test/test-pipeline.jl
+++ b/test/test-pipeline.jl
@@ -33,7 +33,6 @@ end
         end
     end
 
-    # redundant for the current implementation, needed when we support globs
     @testset "check_file(source)" begin
         csv_path = joinpath(DATA, "Norse", "assets*.csv")
         @test TulipaIO.check_file(csv_path)


### PR DESCRIPTION
- `glob` only accepts POSIX paths, so convert platform specific paths to POSIX before passing to `glob`; noop on all platforms except Windows.

- Do not calculate relative path when path and `pwd()` are on different drives, because in that case `relpath` returns a broken path!

## Related issues

There is no related issue.

## Checklist

- [x] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaIO.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
