### PR TITLE
Fix bug where prefix and suffix are not passed if database_schema is empty

### DIFF
--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -49,8 +49,9 @@ function read_csv_folder(
             types = schemas[table_name]
         end
 
+        table_name = "$table_name_prefix$table_name$table_name_suffix"
         if length(database_schema) > 0
-            table_name = "$database_schema.$table_name_prefix$table_name$table_name_suffix"
+            table_name = "$database_schema.$table_name"
         end
 
         create_tbl(


### PR DESCRIPTION
Hotfix for a bug where prefix and suffix are not passed if database_schema is empty.
Updates the test to catch that case.