### PR TITLE
Fix check_file function

### DIFF
--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -12,6 +12,10 @@ _read_opts = pairs((header = true,))
 to_posix(path::String) = replace(path, "\\" => "/")
 
 function check_file(source::String)
+    # Try exact path first (faster path)
+    isfile(source) && return true
+
+    # Fallback to glob pattern matching
     # NOTE: Check if `pwd()` and `source` are on the same drive
     # (relevant only on Windows), if they are not on the same drive,
     # skip call to `relpath` since it returns a path without the drive


### PR DESCRIPTION
The main improvement is to attempt an exact-path check first, which is faster and can avoid errors when using Windows, before falling back to the more expensive glob pattern matching.

## Related issues

Closes #122 

## Checklist

- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaIO.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing