### PR TITLE
Adjust the workflow matrix so macOS uses aarch64

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,10 +25,11 @@ jobs:
                 version:
                     - "lts"
                     - "1"
-                os:
-                    - ubuntu-latest
-                    - macOS-latest
-                    - windows-latest
-                arch:
-                    - x64
+                include:
+                    - os: ubuntu-latest
+                      arch: x64
+                    - os: ubuntu-latest
+                      arch: x64
+                    - os: macOS-latest
+                      arch: aarch64
                 allow_failure: [false]


### PR DESCRIPTION
This pull request updates the matrix configuration for the test workflow in `.github/workflows/Test.yml`. The main change is a switch from listing operating systems and architectures separately to using an `include` matrix, which allows for more explicit pairing of `os` and `arch` combinations.

**Test workflow matrix configuration:**

* Changed from separate `os` and `arch` lists to an explicit `include` matrix, specifying combinations of `os` and `arch` for test runs. This allows for finer control over which OS/architecture pairs are tested, such as adding `macOS-latest` with `aarch64`.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #129 

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [ ] I am following the [contributing guidelines](https://github.com/TulipaEnergy/TulipaIO.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
